### PR TITLE
Enhance monitor pages with full project details

### DIFF
--- a/app/monitor/[id]/page.jsx
+++ b/app/monitor/[id]/page.jsx
@@ -1,49 +1,64 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import Image from "next/image";
 import { motion } from "framer-motion";
+import { FaReact, FaNodeJs } from "react-icons/fa";
+import {
+  SiExpress,
+  SiJavascript,
+  SiMicrosoftsqlserver,
+  SiPostgresql,
+  SiSupabase,
+  SiGoogle,
+  SiOpenai,
+  SiTailwindcss,
+  SiFramer,
+} from "react-icons/si";
 
 const monitors = {
   1: {
-    title: "Monitor 1",
-    content: `En 2022 comenzamos con la idea de digitalizar el aprendizaje de la
-alimentación saludable. Creamos los primeros prototipos de nuestra app
-Nut y recopilamos la información nutricional de los alimentos locales.`,
+    title: "Proyecto Zeta \u2013 Info360 (4\u00ba A\u00f1o \u2013 EFSI)",
+    image: "/zeta-logo.svg",
+    content: `El punto de partida fue comprender un problema real: la mayor\u00eda de las personas no interpreta las etiquetas nutricionales.\n\nTras encuestas, entrevistas y revisi\u00f3n de art\u00edculos comprobamos una gran desinformaci\u00f3n. En el tercer trimestre desarrollamos la Web Zeta para traducir esos datos en informaci\u00f3n clara.\n\nTecnolog\u00eda utilizada:\n- Arquitectura MVC\n- JavaScript + Express.js\n- HTML, CSS y EJS\n- SQL Server\n\nLa plataforma qued\u00f3 terminada ese mismo a\u00f1o y sent\u00f3 las bases de todo lo que vino despu\u00e9s.`,
+    icons: (
+      <div className="flex space-x-3 text-3xl text-zetaGreen">
+        <SiJavascript />
+        <SiExpress />
+        <SiMicrosoftsqlserver />
+      </div>
+    ),
   },
   2: {
-    title: "Monitor 2",
-    content: `A inicios de 2023 lanzamos una versión beta e iniciamos pruebas
-con estudiantes. Mejoramos la interfaz e incorporamos un pequeño scanner
-para reconocer productos mediante código de barras.`,
+    title: "Inteligencia Artificial y App de C\u00e1mara (Inicio de 5\u00ba A\u00f1o)",
+    image: "/camera-app.svg",
+    content: `Buscamos integrar IA a nuestra primera versi\u00f3n. Desarrollamos una aplicaci\u00f3n que usa la c\u00e1mara del celular para escanear productos y ofrecer al instante un an\u00e1lisis nutricional.\n\nFuncionamiento:\n1. El usuario escanea el producto.\n2. Google Vision reconoce la imagen.\n3. GPT genera el par\u00e1metro de b\u00fasqueda.\n4. Consultamos la base de datos y mostramos la informaci\u00f3n clara.\n\nTecnolog\u00eda:\n- React en el frontend\n- Node.js en el backend\n- PostgreSQL en Supabase\n- Google Vision + GPT\n- Estilos CSS puro`,
+    icons: (
+      <div className="flex space-x-3 text-3xl text-zetaGreen">
+        <FaReact />
+        <FaNodeJs />
+        <SiPostgresql />
+        <SiSupabase />
+        <SiGoogle />
+        <SiOpenai />
+      </div>
+    ),
   },
   3: {
-    title: "Monitor 3",
-    content: `Este año dimos el paso más importante: transformamos NUT en un
-proyecto final integral con visión empresarial. Consolidamos la
-tecnología, expandimos las funcionalidades y nos enfocamos en
-experiencia de usuario, accesibilidad y diseño profesional.
-
-Stack actualizado:
-- React con hooks y componentes inteligentes
-- Node.js + Express
-- PostgreSQL alojado en Supabase
-- Tailwind CSS
-- Librerías: React Icons, Framer Motion
-
-La IA del escáner se perfeccionó con modelos para reconocimiento de
-texto conectados a nuestra base nutricional.
-
-NUT es hoy una empresa educativa en crecimiento. Nuestra misión: mejorar
-la salud pública mediante educación alimenticia clara, visual y
-confiable. Trabajamos con visión empresarial, analizando rentabilidad y
-expansión a través de ferias, escuelas y plataformas digitales.
-
-¿Por qué invertir en NUT?
-- Impacto social y educativo real.
-- Modelo escalable.
-- Tecnología moderna.
-- Sinergia interdisciplinaria.
-- Motivación y liderazgo joven.`,
+    title: "Proyecto Final \u2013 NUT y Sinergia (5\u00ba A\u00f1o)",
+    image: "/nut-logo.svg",
+    content: `En el segundo trimestre renombramos el proyecto como NUT y participamos en Sinergia, trabajando junto a otras orientaciones.\n\n- Construcciones: dise\u00f1o de stands y ferias.\n- Gesti\u00f3n de las Organizaciones: modelo de negocio y financiaci\u00f3n.\n- Inform\u00e1tica: plataforma web, IA y experiencia de usuario.\n\nStack actualizado:\n- React con componentes avanzados\n- Node.js + Express\n- PostgreSQL en Supabase\n- Tailwind CSS\n- Librer\u00edas: React Icons y Framer Motion\n\nIntegramos el m\u00f3dulo de c\u00e1mara en la web y definimos una visi\u00f3n a futuro:\n- Ferias educativas en todo el pa\u00eds\n- Integraci\u00f3n con sistemas de salud y educaci\u00f3n\n- Versiones m\u00f3viles y expansi\u00f3n regional\n- Colaboraci\u00f3n con ONGs, escuelas y municipios`,
+    icons: (
+      <div className="flex space-x-3 text-3xl text-zetaGreen">
+        <FaReact />
+        <FaNodeJs />
+        <SiExpress />
+        <SiPostgresql />
+        <SiSupabase />
+        <SiTailwindcss />
+        <SiFramer />
+      </div>
+    ),
   },
 };
 
@@ -70,7 +85,13 @@ export default function Page({ params }) {
         className="max-w-4xl text-left space-y-6"
       >
         <h1 className="text-4xl font-bold text-zetaGreen mb-6">{monitor.title}</h1>
+        {monitor.image && (
+          <div className="flex justify-center">
+            <Image src={monitor.image} alt="logo" width={120} height={120} />
+          </div>
+        )}
         <p className="whitespace-pre-line text-lg leading-relaxed">{monitor.content}</p>
+        {monitor.icons && <div className="mt-4">{monitor.icons}</div>}
         <div className="flex justify-between mt-8 text-zetaGreen font-semibold">
           <button onClick={() => router.push(`/monitor/${prevId}`)}>Anterior</button>
           <button onClick={() => router.push(`/monitor/${nextId}`)}>Siguiente</button>

--- a/app/monitor/page.jsx
+++ b/app/monitor/page.jsx
@@ -1,7 +1,12 @@
+import Image from "next/image";
+
 export default function MonitorIndex() {
   return (
     <main className="min-h-screen flex items-center justify-center p-10 bg-zetaCream text-zetaGray">
-      <p className="text-xl">Por favor, accede mediante el c\u00f3digo QR asignado a cada monitor.</p>
+      <div className="text-center space-y-4">
+        <Image src="/nut-logo.svg" alt="NUT" width={120} height={120} />
+        <p className="text-xl">Por favor, accede mediante el c\u00f3digo QR asignado a cada monitor.</p>
+      </div>
     </main>
   );
 }

--- a/public/camera-app.svg
+++ b/public/camera-app.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <rect x="20" y="30" width="80" height="60" rx="10" fill="#708238" />
+  <circle cx="60" cy="60" r="20" fill="#F4F1E9" />
+</svg>

--- a/public/nut-logo.svg
+++ b/public/nut-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="50" fill="#708238" />
+  <text x="60" y="70" text-anchor="middle" font-size="48" fill="white" font-family="Arial, sans-serif">NUT</text>
+</svg>

--- a/public/zeta-logo.svg
+++ b/public/zeta-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <rect x="10" y="10" width="100" height="100" fill="#DBC04D" rx="20"/>
+  <text x="60" y="70" text-anchor="middle" font-size="40" fill="#4D4D4D" font-family="Arial, sans-serif">Z</text>
+</svg>


### PR DESCRIPTION
## Summary
- expand monitor content with improved descriptions
- show project and stack icons using `react-icons`
- include placeholder logos
- add NUT logo to monitor index page

## Testing
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe353bb48331b3f1fca47f633f15