### PR TITLE
Add decorative GIFs and animated icons

### DIFF
--- a/app/monitor/[id]/page.jsx
+++ b/app/monitor/[id]/page.jsx
@@ -18,6 +18,18 @@ import {
   SiFramer,
 } from "react-icons/si";
 
+const starVariants = {
+  animate: {
+    scale: [1, 1.2, 1],
+    rotate: [0, 45, 0],
+    transition: {
+      repeat: Infinity,
+      duration: 8,
+      ease: "easeInOut",
+    },
+  },
+};
+
 const monitors = {
   1: {
     title: "Proyecto Zeta \u2013 Info360 (4\u00ba A\u00f1o \u2013 EFSI)",
@@ -81,6 +93,13 @@ export default function Page({ params }) {
     <main className="min-h-screen flex flex-col items-center justify-center p-6 sm:p-10 relative overflow-hidden">
       <Image src="/wave-bg.svg" alt="" fill className="absolute inset-0 object-cover" />
       <motion.div
+        variants={starVariants}
+        animate="animate"
+        className="absolute left-8 top-8 w-14 h-14 pointer-events-none"
+      >
+        <Image src="/star.svg" alt="Decorative star" fill />
+      </motion.div>
+      <motion.div
         initial={{ opacity: 0, y: 50 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, amount: 0.3 }}
@@ -126,6 +145,15 @@ export default function Page({ params }) {
             {paragraphs.map((text, idx) => (
               <AnimatedParagraph key={idx}>{text}</AnimatedParagraph>
             ))}
+            <div className="flex justify-center">
+              <Image
+                src="https://media.giphy.com/media/26BRuo6sLetdllPAQ/giphy.gif"
+                alt="Decorative animation"
+                width={200}
+                height={200}
+                className="rounded-lg"
+              />
+            </div>
             {monitor.icons && <div>{monitor.icons}</div>}
           </motion.div>
         </motion.div>

--- a/app/monitor/page.jsx
+++ b/app/monitor/page.jsx
@@ -4,10 +4,29 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import AnimatedParagraph from "../../components/AnimatedParagraph";
 
+const starVariants = {
+  animate: {
+    y: [0, -15, 0],
+    rotate: [0, 45, 0],
+    transition: {
+      repeat: Infinity,
+      duration: 6,
+      ease: "easeInOut",
+    },
+  },
+};
+
 export default function MonitorIndex() {
   return (
     <main className="min-h-screen flex items-center justify-center p-6 sm:p-10 relative overflow-hidden">
       <Image src="/wave-bg.svg" alt="" fill className="absolute inset-0 object-cover" />
+      <motion.div
+        variants={starVariants}
+        animate="animate"
+        className="absolute left-8 top-8 w-14 h-14 pointer-events-none"
+      >
+        <Image src="/star.svg" alt="Decorative star" fill />
+      </motion.div>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -21,10 +40,19 @@ export default function MonitorIndex() {
           height={140}
           className="mx-auto w-20 h-20 md:w-36 md:h-36"
         />
-          <AnimatedParagraph>
-            Por favor, accede mediante el código QR asignado a cada monitor.
-          </AnimatedParagraph>
-          <Link href="/monitor/1" className="inline-block px-6 py-3 bg-zetaGreen text-white rounded-lg hover:bg-zetaBlue transition-colors text-base">Comenzar</Link>
+        <AnimatedParagraph>
+          Por favor, accede mediante el código QR asignado a cada monitor.
+        </AnimatedParagraph>
+        <div className="flex justify-center">
+          <Image
+            src="https://media.giphy.com/media/xTiTnoHt2pT76JPrX6/giphy.gif"
+            alt="Decorative animation"
+            width={200}
+            height={200}
+            className="rounded-lg"
+          />
+        </div>
+        <Link href="/monitor/1" className="inline-block px-6 py-3 bg-zetaGreen text-white rounded-lg hover:bg-zetaBlue transition-colors text-base">Comenzar</Link>
       </motion.div>
     </main>
   );

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,10 +4,29 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import AnimatedParagraph from "../components/AnimatedParagraph";
 
+const starVariants = {
+  animate: {
+    y: [0, -20, 0],
+    rotate: [0, 45, 0],
+    transition: {
+      repeat: Infinity,
+      duration: 6,
+      ease: "easeInOut",
+    },
+  },
+};
+
 export default function Home() {
   return (
     <main className="relative min-h-screen flex items-center justify-center text-center overflow-hidden p-6 sm:p-8">
       <Image src="/wave-bg.svg" alt="" fill className="absolute inset-0 object-cover" />
+      <motion.div
+        variants={starVariants}
+        animate="animate"
+        className="absolute top-10 right-10 w-16 h-16 pointer-events-none"
+      >
+        <Image src="/star.svg" alt="Decorative star" fill />
+      </motion.div>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -28,6 +47,15 @@ export default function Home() {
           Explora nuestra evolución y descubre cómo usamos la tecnología
           para mejorar la educación alimentaria.
         </AnimatedParagraph>
+        <div className="flex justify-center">
+          <Image
+            src="https://media.giphy.com/media/fuJPZBIIqTtlw/giphy.gif"
+            alt="Animación decorativa"
+            width={200}
+            height={200}
+            className="rounded-lg"
+          />
+        </div>
         <Link
           href="/monitor/1"
           className="inline-block px-6 py-3 bg-zetaGreen text-white rounded-lg hover:bg-zetaBlue transition-colors text-base"

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    domains: ['media.giphy.com', 'images.unsplash.com']
+  }
+}
 
 module.exports = nextConfig

--- a/public/star.svg
+++ b/public/star.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="32,4 39,24 60,24 42,38 48,58 32,46 16,58 22,38 4,24 25,24" fill="#DBC04D"/>
+</svg>


### PR DESCRIPTION
## Summary
- allow remote images for GIFs
- add decorative star vector
- decorate home page with animated star and GIF
- decorate monitor index and pages with animated assets

## Testing
- `npm run build` *(fails: Failed to fetch font `Poppins`)*

------
https://chatgpt.com/codex/tasks/task_e_685e72ffa9888331ae4be35c45c33ca3